### PR TITLE
[games-board/netmaumau] fix to connect to older servers

### DIFF
--- a/games-board/netmaumau/files/connect-to-old-servers-netmaumau-0.16.patch
+++ b/games-board/netmaumau/files/connect-to-old-servers-netmaumau-0.16.patch
@@ -1,0 +1,12 @@
+diff -uNr NetMauMau-Qt-Client-0.16.orig/src/client.cpp NetMauMau-Qt-Client-0.16/src/client.cpp
+--- NetMauMau-Qt-Client-0.16.orig/src/client.cpp	2015-03-07 04:39:42.000000000 +0100
++++ NetMauMau-Qt-Client-0.16/src/client.cpp	2015-03-17 06:44:07.850291172 +0100
+@@ -32,7 +32,7 @@
+ #include "mainwindow.h"
+ #include "base64bridge.h"
+ 
+-#define CLIENTVERSION 16
++#define CLIENTVERSION 15
+ 
+ Client::Client(MainWindow *const w, ConnectionLogDialog *cld, const QString &player,
+ 			   const std::string &server, uint16_t port) : QThread(),

--- a/games-board/netmaumau/netmaumau-0.16-r1.ebuild
+++ b/games-board/netmaumau/netmaumau-0.16-r1.ebuild
@@ -32,6 +32,10 @@ DEPEND="
 
 S=${WORKDIR}/${P}-client
 
+src_prepare() {
+	epatch "${FILESDIR}/connect-to-old-servers-${P}.patch"
+}
+
 src_configure() {
 	if use espeak; then USE_ESPEAK='CONFIG+=espeak'; fi
 	eqmake4 $USE_ESPEAK


### PR DESCRIPTION
Since *Gentoo* is a source distro it is easy to push bugfixes after release :smile_cat: 

See https://github.com/velnias75/NetMauMau-Qt-Client/issues/27 which I have backported.

:warning: if I need to modify that PR too much, better to reject it. You know how much I *love* git...