### PR TITLE
[games-server/netmaumau] patch to fix inetd mode if built with LTO

### DIFF
--- a/games-server/netmaumau/files/netmaumau-fix-lto-inetd.patch
+++ b/games-server/netmaumau/files/netmaumau-fix-lto-inetd.patch
@@ -1,0 +1,13 @@
+diff -uNr NetMauMau-0.12.orig/src/common/basiclogger.h NetMauMau-0.12/src/common/basiclogger.h
+--- NetMauMau-0.12.orig/src/common/basiclogger.h	2015-01-28 13:32:03.000000000 +0100
++++ NetMauMau-0.12/src/common/basiclogger.h	2015-04-03 11:23:33.389799063 +0200
+@@ -181,7 +181,8 @@
+ 		size_t fatal;
+ 	} m_logCount;
+ 
+-	static unsigned char m_silentMask;
++	// we need this in order to get the combination LTO & inetd to work
++	__attribute__((externally_visible)) static unsigned char m_silentMask;
+ 
+ 	LEVEL m_level;
+ 

--- a/games-server/netmaumau/netmaumau-0.12-r2.ebuild
+++ b/games-server/netmaumau/netmaumau-0.12-r2.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="http://sourceforge.net/projects/netmaumau"
 SRC_URI="https://github.com/velnias75/NetMauMau/archive/V${PV}.tar.gz -> ${P}-server.tar.gz"
 
 LICENSE="LGPL-3"
-SLOT="0/6"
+SLOT="0/5"
 KEYWORDS="~amd64 ~x86"
 IUSE="cli-client doc static-libs"
 
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 

--- a/games-server/netmaumau/netmaumau-0.13-r2.ebuild
+++ b/games-server/netmaumau/netmaumau-0.13-r2.ebuild
@@ -11,9 +11,9 @@ HOMEPAGE="http://sourceforge.net/projects/netmaumau"
 SRC_URI="https://github.com/velnias75/NetMauMau/archive/V${PV}.tar.gz -> ${P}-server.tar.gz"
 
 LICENSE="LGPL-3"
-SLOT="0/7"
+SLOT="0/6"
 KEYWORDS="~amd64 ~x86"
-IUSE="branding cli-client dedicated doc static-libs"
+IUSE="cli-client doc static-libs"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 
@@ -39,15 +40,14 @@ src_configure() {
 	append-cppflags -DNDEBUG
 
 	econf \
-		$(use_enable !dedicated client) \
+		--enable-client \
 		--enable-xinetd \
-		$(usex dedicated "--disable-cli-client" "$(use_enable cli-client)") \
+		$(use_enable cli-client) \
 		$(use_enable doc apidoc) \
+		--enable-ai-name="Gentoo Hero" \
 		--docdir=/usr/share/doc/${PF} \
 		--localstatedir=/var/lib/games/ \
-		$(use_enable static-libs static) \
-		"$(use_enable branding ai-name 'Gentoo Hero')" \
-		$(use_enable branding ai-image "${FILESDIR}"/gblend.png)
+		$(use_enable static-libs static)
 }
 
 src_install() {
@@ -58,12 +58,10 @@ src_install() {
 }
 
 pkg_postinst() {
-	if ! use dedicated ; then
-		elog "This is only the server part, you might want to install"
-		elog "the client too:"
-		elog "  games-board/netmaumau"
-		elog
-	fi
+	elog "This is only the server part, you might want to install"
+	elog "the client too:"
+	elog "  games-board/netmaumau"
+	elog
 	elog "This server also installs a xinetd service. You need"
 	elog "  sys-apps/xinetd"
 	elog "if you want to get the server started on demand."

--- a/games-server/netmaumau/netmaumau-0.14-r1.ebuild
+++ b/games-server/netmaumau/netmaumau-0.14-r1.ebuild
@@ -11,9 +11,9 @@ HOMEPAGE="http://sourceforge.net/projects/netmaumau"
 SRC_URI="https://github.com/velnias75/NetMauMau/archive/V${PV}.tar.gz -> ${P}-server.tar.gz"
 
 LICENSE="LGPL-3"
-SLOT="0/5"
+SLOT="0/7"
 KEYWORDS="~amd64 ~x86"
-IUSE="cli-client doc static-libs"
+IUSE="branding cli-client dedicated doc static-libs"
 
 RDEPEND="
 	dev-db/sqlite:3
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 
@@ -39,14 +40,15 @@ src_configure() {
 	append-cppflags -DNDEBUG
 
 	econf \
-		--enable-client \
+		$(use_enable !dedicated client) \
 		--enable-xinetd \
-		$(use_enable cli-client) \
+		$(usex dedicated "--disable-cli-client" "$(use_enable cli-client)") \
 		$(use_enable doc apidoc) \
-		--enable-ai-name="Gentoo Hero" \
 		--docdir=/usr/share/doc/${PF} \
 		--localstatedir=/var/lib/games/ \
-		$(use_enable static-libs static)
+		$(use_enable static-libs static) \
+		"$(use_enable branding ai-name 'Gentoo Hero')" \
+		$(use_enable branding ai-image "${FILESDIR}"/gblend.png)
 }
 
 src_install() {
@@ -57,10 +59,12 @@ src_install() {
 }
 
 pkg_postinst() {
-	elog "This is only the server part, you might want to install"
-	elog "the client too:"
-	elog "  games-board/netmaumau"
-	elog
+	if ! use dedicated ; then
+		elog "This is only the server part, you might want to install"
+		elog "the client too:"
+		elog "  games-board/netmaumau"
+		elog
+	fi
 	elog "This server also installs a xinetd service. You need"
 	elog "  sys-apps/xinetd"
 	elog "if you want to get the server started on demand."

--- a/games-server/netmaumau/netmaumau-0.15-r1.ebuild
+++ b/games-server/netmaumau/netmaumau-0.15-r1.ebuild
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 

--- a/games-server/netmaumau/netmaumau-0.16-r1.ebuild
+++ b/games-server/netmaumau/netmaumau-0.16-r1.ebuild
@@ -32,6 +32,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 

--- a/games-server/netmaumau/netmaumau-0.17.0-r1.ebuild
+++ b/games-server/netmaumau/netmaumau-0.17.0-r1.ebuild
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${PN}-fix-lto-inetd.patch"
 	eautoreconf
 }
 


### PR DESCRIPTION
This PR will fix the *NetMauMau server* if

 * built with *link time optimization* (**LTO**)
 * started by *(x)inetd* (i.e. with `--inetd` command line option)

without that patch the *NetMauMau server* wants to log on the *pty* instead of *syslog* only and so bringing (x)inetd in disorder and deciding to let the *NetMauMau server* crash.

A *harmless* variable attribute protects the internal static configuration variable of the logger, so the *NetMauMau server* will again log **only** to *sylog* if started with `--inetd` command line option.

Since the *same* patch applies to **all** versions I *omitted* the version number.