### PR TITLE
[games-server/netmaumau] added netmaumau-0.21.0-ctime.patch

### DIFF
--- a/games-server/netmaumau/files/netmaumau-0.21.0-ctime.patch
+++ b/games-server/netmaumau/files/netmaumau-0.21.0-ctime.patch
@@ -1,0 +1,12 @@
+diff -uNr netmaumau-0.21.0~precise.orig/src/engine/easyplayer.cpp netmaumau-0.21.0~precise/src/engine/easyplayer.cpp
+--- netmaumau-0.21.0~precise.orig/src/engine/easyplayer.cpp	2015-06-13 04:41:53.000000000 +0200
++++ netmaumau-0.21.0~precise/src/engine/easyplayer.cpp	2015-06-15 04:44:25.186496994 +0200
+@@ -21,6 +21,8 @@
+ #include "config.h"                     // IWYU pragma: keep
+ #endif
+ 
++#include <ctime>
++
+ #include "easyplayer.h"
+ 
+ #include "random_gen.h"                 // for genRandom

--- a/games-server/netmaumau/netmaumau-0.21.0-r1.ebuild
+++ b/games-server/netmaumau/netmaumau-0.21.0-r1.ebuild
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}
 S=${WORKDIR}/${P}-server
 
 src_prepare() {
+	epatch "${FILESDIR}/${P}-ctime.patch"
 	eautoreconf
 }
 
@@ -69,7 +70,7 @@ pkg_postinst() {
                 if [ -n "`pgrep -f "inetd"`" ]; then
 			elog "Detected a NetMauMau server started from (x)inetd."
                         elog "Stopping nmm-server to spawn the newly installed instance at next request…"
-                        killall nmm-server
+                        killall nmm-server 2> /dev/null
                 fi
         fi
 


### PR DESCRIPTION
Fixes a potential compile error. At least build failed on *Arch Core* with `gcc-5.1` and `glibc 2.21`.