### PR TITLE
[games-strategy/hedgewars] fix dependencies

### DIFF
--- a/games-strategy/hedgewars/hedgewars-0.9.20.5-r1.ebuild
+++ b/games-strategy/hedgewars/hedgewars-0.9.20.5-r1.ebuild
@@ -23,10 +23,9 @@ QA_FLAGS_IGNORED=/usr/bin/hwengine
 QA_PRESTRIPPED=/usr/bin/hwengine
 
 CDEPEND="
+	dev-lang/lua
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
-	>=media-fonts/dejavu-2.28
-	media-fonts/wqy-zenhei
 	media-libs/freeglut
 	media-libs/libpng:0
 	media-libs/libsdl[sound,opengl,video]
@@ -37,44 +36,48 @@ CDEPEND="
 	sys-libs/zlib
 	virtual/ffmpeg
 	server? (
-		>=dev-libs/gmp-5
-		virtual/libffi
-	)
-"
-RDEPEND="${CDEPEND}"
-DEPEND="${CDEPEND}
-	>=dev-lang/fpc-2.4
-	server? (
 		dev-haskell/binary
 		dev-haskell/bytestring-show
 		dev-haskell/dataenc
-		dev-haskell/deepseq
-		dev-haskell/entropy
 		dev-haskell/hslogger
 		>=dev-haskell/mtl-2.0.1.0
 		>=dev-haskell/network-2.3
 		>=dev-haskell/parsec-3
-		dev-haskell/random
-		dev-haskell/sha
 		dev-haskell/utf8-string
 		dev-haskell/vector
-		dev-haskell/zlib
-		>=dev-lang/ghc-7.0
+		dev-haskell/random
+		>=dev-libs/gmp-5:=
+		virtual/libffi:=
 	)
+"
+DEPEND="${CDEPEND}
+	>=dev-lang/fpc-2.4
+	>=dev-lang/ghc-7.0:=
+"
+RDEPEND="${CDEPEND}
+	media-fonts/wqy-zenhei
+	>=media-fonts/dejavu-2.28
 "
 
 S=${WORKDIR}/${PN}-src-${PV:0:6}
 
+src_prepare() {
+	# see http://code.google.com/p/hedgewars/issues/detail?id=798
+	epatch "${FILESDIR}"/${P}-ghc-7.8.patch
+
+	epatch "${FILESDIR}"/${P}-cmake3.patch
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DMINIMAL_FLAGS=ON
+		-DCMAKE_INSTALL_PREFIX=/usr/bin
 		-DDATA_INSTALL_DIR="/usr/share/${PN}"
+		-Dtarget_binary_install_dir=/usr/bin
 		-Dtarget_library_install_dir="/usr/$(get_libdir)"
 		$(cmake-utils_use !server NOSERVER)
 		-DCMAKE_VERBOSE_MAKEFILE=TRUE
-		-DLUA_SYSTEM=OFF
 		-DPHYSFS_SYSTEM=OFF
-		-DFONTS_DIRS="/usr/share/fonts/dejavu;/usr/share/fonts/wqy-zenhei"
 	)
 	cmake-utils_src_configure
 }
@@ -85,6 +88,11 @@ src_compile() {
 
 src_install() {
 	DOCS="ChangeLog.txt README" cmake-utils_src_install
+	rm -f "${D%/}"/usr/share/hedgewars/Data/Fonts/{DejaVuSans-Bold.ttf,wqy-zenhei.ttc}
+	dosym /usr/share/fonts/dejavu/DejaVuSans-Bold.ttf \
+		/usr/share/${PN}/Data/Fonts/DejaVuSans-Bold.ttf
+	dosym /usr/share/fonts/wqy-zenhei/wqy-zenhei.ttc \
+		/usr/share/${PN}/Data/Fonts/wqy-zenhei.ttc
 	doicon misc/hedgewars.png
 	make_desktop_entry ${PN} Hedgewars
 	doman man/${PN}.6

--- a/games-strategy/hedgewars/hedgewars-0.9.21-r2.ebuild
+++ b/games-strategy/hedgewars/hedgewars-0.9.21-r2.ebuild
@@ -23,9 +23,10 @@ QA_FLAGS_IGNORED=/usr/bin/hwengine
 QA_PRESTRIPPED=/usr/bin/hwengine
 
 CDEPEND="
-	dev-lang/lua
 	dev-qt/qtcore:4
 	dev-qt/qtgui:4
+	>=media-fonts/dejavu-2.28
+	media-fonts/wqy-zenhei
 	media-libs/freeglut
 	media-libs/libpng:0
 	media-libs/libsdl[sound,opengl,video]
@@ -36,49 +37,43 @@ CDEPEND="
 	sys-libs/zlib
 	virtual/ffmpeg
 	server? (
+		>=dev-libs/gmp-5
+		virtual/libffi
+	)
+"
+RDEPEND="${CDEPEND}"
+DEPEND="${CDEPEND}
+	>=dev-lang/fpc-2.4
+	server? (
 		dev-haskell/binary
 		dev-haskell/bytestring-show
 		dev-haskell/dataenc
-		dev-haskell/deepseq
+		dev-haskell/entropy
 		dev-haskell/hslogger
 		>=dev-haskell/mtl-2.0.1.0
 		>=dev-haskell/network-2.3
 		>=dev-haskell/parsec-3
+		dev-haskell/random
+		dev-haskell/sha
 		dev-haskell/utf8-string
 		dev-haskell/vector
-		dev-haskell/random
-		>=dev-libs/gmp-5:=
-		virtual/libffi:=
+		dev-haskell/zlib
+		>=dev-lang/ghc-7.0
 	)
-"
-DEPEND="${CDEPEND}
-	>=dev-lang/fpc-2.4
-	>=dev-lang/ghc-7.0:=
-"
-RDEPEND="${CDEPEND}
-	media-fonts/wqy-zenhei
-	>=media-fonts/dejavu-2.28
 "
 
 S=${WORKDIR}/${PN}-src-${PV:0:6}
 
-src_prepare() {
-	# see http://code.google.com/p/hedgewars/issues/detail?id=798
-	epatch "${FILESDIR}"/${P}-ghc-7.8.patch
-
-	epatch "${FILESDIR}"/${P}-cmake3.patch
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DMINIMAL_FLAGS=ON
-		-DCMAKE_INSTALL_PREFIX=/usr/bin
 		-DDATA_INSTALL_DIR="/usr/share/${PN}"
-		-Dtarget_binary_install_dir=/usr/bin
 		-Dtarget_library_install_dir="/usr/$(get_libdir)"
 		$(cmake-utils_use !server NOSERVER)
 		-DCMAKE_VERBOSE_MAKEFILE=TRUE
+		-DLUA_SYSTEM=OFF
 		-DPHYSFS_SYSTEM=OFF
+		-DFONTS_DIRS="/usr/share/fonts/dejavu;/usr/share/fonts/wqy-zenhei"
 	)
 	cmake-utils_src_configure
 }
@@ -89,11 +84,6 @@ src_compile() {
 
 src_install() {
 	DOCS="ChangeLog.txt README" cmake-utils_src_install
-	rm -f "${D%/}"/usr/share/hedgewars/Data/Fonts/{DejaVuSans-Bold.ttf,wqy-zenhei.ttc}
-	dosym /usr/share/fonts/dejavu/DejaVuSans-Bold.ttf \
-		/usr/share/${PN}/Data/Fonts/DejaVuSans-Bold.ttf
-	dosym /usr/share/fonts/wqy-zenhei/wqy-zenhei.ttc \
-		/usr/share/${PN}/Data/Fonts/wqy-zenhei.ttc
 	doicon misc/hedgewars.png
 	make_desktop_entry ${PN} Hedgewars
 	doman man/${PN}.6

--- a/games-strategy/hedgewars/hedgewars-0.9.21.1-r2.ebuild
+++ b/games-strategy/hedgewars/hedgewars-0.9.21.1-r2.ebuild
@@ -48,7 +48,6 @@ DEPEND="${CDEPEND}
 		dev-haskell/binary
 		dev-haskell/bytestring-show
 		dev-haskell/dataenc
-		dev-haskell/deepseq
 		dev-haskell/entropy
 		dev-haskell/hslogger
 		>=dev-haskell/mtl-2.0.1.0


### PR DESCRIPTION
dev-haskell/deepseq is masked as it is part of >=dev-lang/ghc-7.4