### PR TITLE
games-fps/unvanquished: create ${PN}-server group

### DIFF
--- a/games-fps/unvanquished/unvanquished-0.48.0.ebuild
+++ b/games-fps/unvanquished/unvanquished-0.48.0.ebuild
@@ -75,6 +75,7 @@ pkg_pretend() {
 
 pkg_setup() {
 	if use server || use dedicated ; then
+		enewgroup "${PN}-server"
 		enewuser \
 			"${PN}-server" \
 			"-1" \


### PR DESCRIPTION
Not done implicitly, so the build was broken.