### PR TITLE
>=wesnoth-1.13.3 requires SDL2 libraries

### DIFF
--- a/games-strategy/wesnoth/wesnoth-1.13.6.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.13.6.ebuild
@@ -25,9 +25,9 @@ RDEPEND="
 		dev-libs/glib:2
 		media-libs/fontconfig
 		media-libs/libpng:0
-		>=media-libs/sdl-ttf-2.0.8
-		>=media-libs/sdl-mixer-1.2[vorbis]
-		>=media-libs/sdl-image-1.2[jpeg,png]
+		media-libs/sdl2-ttf
+		media-libs/sdl2-mixer[vorbis]
+		media-libs/sdl2-image[jpeg,png]
 		media-libs/libvorbis
 		sys-libs/readline:0
 		sys-libs/zlib


### PR DESCRIPTION
As per the [changelog](https://raw.githubusercontent.com/wesnoth/wesnoth/1.13.7/players_changelog),
>Version 1.13.3:
> * SDL 2 is now used by default when building.