### PR TITLE
games-action/minetest-game: Set PaX flags

### DIFF
--- a/games-action/minetest/minetest-9999.ebuild
+++ b/games-action/minetest/minetest-9999.ebuild
@@ -3,7 +3,7 @@
 # $Id$
 
 EAPI=5
-inherit cmake-utils git-r3 gnome2-utils user
+inherit cmake-utils git-r3 gnome2-utils pax-utils user
 
 DESCRIPTION="An InfiniMiner/Minecraft inspired game"
 HOMEPAGE="http://minetest.net/"
@@ -108,9 +108,14 @@ src_install() {
 	cmake-utils_src_install
 
 	if use server || use dedicated ; then
+	        pax-mark m "${D}"usr/bin/minetestserver
 		newinitd "${FILESDIR}"/minetestserver.initd minetest-server
 		newconfd "${T}"/minetestserver.confd minetest-server
 	fi
+
+        if ! use dedicated ; then
+                pax-mark m "${D}"usr/bin/minetest
+        fi
 
 	if use doc ; then
 		cd "${CMAKE_BUILD_DIR}"/doc || die


### PR DESCRIPTION
Fixes issue #70.
Shouldn't yet be merged, because it fixes the PaX flags only for minetest-9999, and not for the other versions that might need it. I didn't check whether PaX is a problem with the older versions (probably is…).